### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/1-feature-request.yml
@@ -1,0 +1,11 @@
+name: Feature Request
+description: Request a new feature.
+title: "Feature: <title>"
+labels: [feature, triage]
+body:
+  - type: textarea
+    attributes:
+      label: Feature description
+      description: A clear and concise description of what you want to happen and what problem will this solve.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-bug.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug.yml
@@ -1,0 +1,29 @@
+name: Bug
+description: Report a bug.
+title: "Bug: <title>"
+labels: [bug, triage]
+body:
+  - type: textarea
+    attributes:
+      label: Bug description
+      description: A concise description of what you're experiencing and what you expected to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Version
+      description: "Version of the Conduit connector as well as version of the Kafka connector you're using."
+      placeholder: v0.1.0
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-bug.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug.yml
@@ -23,7 +23,7 @@ body:
   - type: input
     attributes:
       label: Version
-      description: "Version of the Conduit connector as well as version of the Kafka connector you're using."
+      description: "Version of the Conduit connector as well as version of the S3 connector you're using."
       placeholder: v0.1.0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ❓ Ask a Question
+    url: https://github.com/ConduitIO/conduit/discussions
+    about: Please ask and answer questions here.


### PR DESCRIPTION
### Description

Adds issue templates (similar to what we have in the main repo).

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-postgres/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
