### PR TITLE
fix extra empty file bug

### DIFF
--- a/destination/destination.go
+++ b/destination/destination.go
@@ -110,6 +110,10 @@ func (d *Destination) Teardown(ctx context.Context) error {
 }
 
 func (d *Destination) Flush(ctx context.Context) error {
+	if len(d.Buffer) == 0 {
+		return nil
+	}
+
 	bufferedRecords := d.Buffer
 	d.Buffer = d.Buffer[:0]
 

--- a/destination/destination_test.go
+++ b/destination/destination_test.go
@@ -62,6 +62,16 @@ func TestLocalParquet(t *testing.T) {
 		}
 	}
 
+	err = destination.Flush(ctx)
+	if err != nil {
+		t.Fatalf("failed to Flush: %v", err)
+	}
+
+	err = destination.Teardown(ctx)
+	if err != nil {
+		t.Fatalf("failed to Teardown: %v", err)
+	}
+
 	// The code above should produce two files in the fixtures directory:
 	// - local-0001.parquet
 	// - local-0002.parquet
@@ -113,6 +123,16 @@ func TestLocalJSON(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Write returned an error: %v", err)
 		}
+	}
+
+	err = destination.Flush(ctx)
+	if err != nil {
+		t.Fatalf("failed to Flush: %v", err)
+	}
+
+	err = destination.Teardown(ctx)
+	if err != nil {
+		t.Fatalf("failed to Teardown: %v", err)
 	}
 
 	// The code above should produce two files in the fixtures directory:
@@ -198,6 +218,17 @@ func TestS3Parquet(t *testing.T) {
 		t.Fatalf("Destination writer expected to be writer.S3, but is actually %+v", writer)
 	}
 
+	err = destination.Flush(ctx)
+	if err != nil {
+		t.Fatalf("failed to Flush: %v", err)
+	}
+
+	err = destination.Teardown(ctx)
+	if err != nil {
+		t.Fatalf("failed to Teardown: %v", err)
+	}
+
+	// check if only two files are written
 	if len(writer.FilesWritten) != 2 {
 		t.Fatalf("Expected writer to have written 2 files, got %d", len(writer.FilesWritten))
 	}


### PR DESCRIPTION
### Description

while working on acceptance tests.. noticed that an extra empty file is written to the S3 destination
`Flush` method was called at the end and the buffer was empty.. so i added a simple check there

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-s3/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
