### PR TITLE
Add support for using `prefix` to Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ the S3 bucket.
 
 The config passed to `Configure` can contain the following fields.
 
-| name                  | description                                                                            | required  | example             |
-|-----------------------|----------------------------------------------------------------------------------------|-----------|---------------------|
-| `aws.accessKeyId`     | AWS access key id                                                                      | yes       | "THE_ACCESS_KEY_ID" |
-| `aws.secretAccessKey` | AWS secret access key                                                                  | yes       | "SECRET_ACCESS_KEY" |
-| `aws.region`          | the AWS S3 bucket region                                                               | yes       | "us-east-1"         |
-| `aws.bucket`          | the AWS S3 bucket name                                                                 | yes       | "bucket_name"       |
-| `pollingPeriod`       | polling period for the CDC mode, formatted as a time.Duration string. default is "1s"  | no        | "2s", "500ms"       |
+| name                  | description                                                                           | required | example             |
+| --------------------- | ------------------------------------------------------------------------------------- | -------- | ------------------- |
+| `aws.accessKeyId`     | AWS access key id                                                                     | yes      | "THE_ACCESS_KEY_ID" |
+| `aws.secretAccessKey` | AWS secret access key                                                                 | yes      | "SECRET_ACCESS_KEY" |
+| `aws.region`          | the AWS S3 bucket region                                                              | yes      | "us-east-1"         |
+| `aws.bucket`          | the AWS S3 bucket name                                                                | yes      | "bucket_name"       |
+| `pollingPeriod`       | polling period for the CDC mode, formatted as a time.Duration string. default is "1s" | no       | "2s", "500ms"       |
+| `prefix`              | the key prefix for S3 source                                                          | no       | "conduit-"          |
 
 ### Known Limitations
 

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,9 @@ const (
 
 	// ConfigKeyAWSBucket is the config name for AWS S3 bucket
 	ConfigKeyAWSBucket = "aws.bucket"
+
+	// ConfigKeyPrefix is the config name for S3 key prefix.
+	ConfigKeyPrefix = "prefix"
 )
 
 // Config represents configuration needed for S3
@@ -36,6 +39,7 @@ type Config struct {
 	AWSSecretAccessKey string
 	AWSRegion          string
 	AWSBucket          string
+	Prefix             string
 }
 
 // Parse attempts to parse plugins.Config into a Config struct
@@ -64,11 +68,14 @@ func Parse(cfg map[string]string) (Config, error) {
 		return Config{}, requiredConfigErr(ConfigKeyAWSBucket)
 	}
 
+	prefix := cfg[ConfigKeyPrefix]
+
 	config := Config{
 		AWSAccessKeyID:     accessKeyID,
 		AWSSecretAccessKey: secretAccessKey,
 		AWSRegion:          region,
 		AWSBucket:          bucket,
+		Prefix:             prefix,
 	}
 
 	return config, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,6 +23,7 @@ var exampleConfig = map[string]string{
 	"aws.secretAccessKey": "secret-key-321",
 	"aws.region":          "us-west-2",
 	"aws.bucket":          "foobucket",
+	"prefix":              "conduit-",
 }
 
 func configWith(pairs ...string) map[string]string {
@@ -165,4 +166,16 @@ func TestAWSBucket(t *testing.T) {
 			t.Fatalf("expected error msg to be %q, got %q", expectedErrMsg, err.Error())
 		}
 	})
+}
+
+func TestPrefix(t *testing.T) {
+	c, err := Parse(configWith("prefix", "some/value"))
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if c.Prefix != "some/value" {
+		t.Fatalf("expected Prefix to be %q, got %q", "some/value", c.Prefix)
+	}
 }

--- a/destination/config.go
+++ b/destination/config.go
@@ -25,16 +25,12 @@ import (
 const (
 	// ConfigKeyFormat is the config name for destination format.
 	ConfigKeyFormat = "format"
-
-	// ConfigKeyPrefix is the config name for S3 destination key prefix.
-	ConfigKeyPrefix = "prefix"
 )
 
 // Config represents S3 configuration with Destination specific configurations
 type Config struct {
 	config.Config
 	Format format.Format
-	Prefix string
 }
 
 // Parse attempts to parse plugins.Config into a Config struct that Destination could
@@ -68,11 +64,8 @@ func Parse(cfg map[string]string) (Config, error) {
 		)
 	}
 
-	prefix := cfg[ConfigKeyPrefix]
-
 	destinationConfig := Config{
 		Config: common,
-		Prefix: prefix,
 		Format: formatValue,
 	}
 

--- a/destination/config_test.go
+++ b/destination/config_test.go
@@ -83,15 +83,3 @@ func TestFormat(t *testing.T) {
 		}
 	})
 }
-
-func TestPrefix(t *testing.T) {
-	c, err := Parse(configWith("prefix", "some/value"))
-
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	if c.Prefix != "some/value" {
-		t.Fatalf("expected Prefix to be %q, got %q", "some/value", c.Prefix)
-	}
-}

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -58,15 +58,15 @@ func (d *Destination) Parameters() map[string]sdk.Parameter {
 			Required:    true,
 			Description: "the AWS S3 bucket name.",
 		},
+		config.ConfigKeyPrefix: {
+			Default:     "",
+			Required:    false,
+			Description: "the key prefix for S3 destination.",
+		},
 		ConfigKeyFormat: {
 			Default:     "",
 			Required:    false,
 			Description: `the destination format, either "json" or "parquet".`,
-		},
-		ConfigKeyPrefix: {
-			Default:     "",
-			Required:    false,
-			Description: "the key prefix for S3 destination.",
 		},
 	}
 }

--- a/destination/destination_test.go
+++ b/destination/destination_test.go
@@ -157,8 +157,8 @@ func TestS3Parquet(t *testing.T) {
 		config.ConfigKeyAWSSecretAccessKey: env[EnvAWSSecretAccessKey],
 		config.ConfigKeyAWSRegion:          env[EnvAWSRegion],
 		config.ConfigKeyAWSBucket:          env[EnvAWSS3Bucket],
+		config.ConfigKeyPrefix:             "test",
 		ConfigKeyFormat:                    "parquet",
-		ConfigKeyPrefix:                    "test",
 	})
 	if err != nil {
 		t.Fatalf("failed to parse the Configuration: %v", err)

--- a/source/iterator/snapshot_iterator.go
+++ b/source/iterator/snapshot_iterator.go
@@ -38,9 +38,10 @@ type SnapshotIterator struct {
 
 // NewSnapshotIterator takes the s3 bucket, the client, and the position.
 // it returns a snapshotIterator starting from the position provided.
-func NewSnapshotIterator(bucket string, client *s3.Client, p position.Position) (*SnapshotIterator, error) {
+func NewSnapshotIterator(bucket, prefix string, client *s3.Client, p position.Position) (*SnapshotIterator, error) {
 	input := &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucket),
+		Prefix: aws.String(prefix),
 	}
 
 	return &SnapshotIterator{

--- a/source/source.go
+++ b/source/source.go
@@ -68,6 +68,11 @@ func (s *Source) Parameters() map[string]sdk.Parameter {
 			Required:    true,
 			Description: "the AWS S3 bucket name.",
 		},
+		config.ConfigKeyPrefix: {
+			Default:     "",
+			Required:    false,
+			Description: "the key prefix for S3 source.",
+		},
 		ConfigKeyPollingPeriod: {
 			Default:     DefaultPollingPeriod,
 			Required:    false,
@@ -120,7 +125,9 @@ func (s *Source) Open(ctx context.Context, rp sdk.Position) error {
 		return err
 	}
 
-	s.iterator, err = iterator.NewCombinedIterator(s.config.AWSBucket, s.config.PollingPeriod, s.client, p)
+	s.iterator, err = iterator.NewCombinedIterator(
+		s.config.AWSBucket, s.config.Prefix, s.config.PollingPeriod, s.client, p,
+	)
 	if err != nil {
 		return fmt.Errorf("couldn't create a combined iterator: %w", err)
 	}


### PR DESCRIPTION
### Description

This PR seeks to add support for using `prefix` to Source.

Fixes #143

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-s3/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
