### PR TITLE
Fix: copyright year doesn't have to be the current year

### DIFF
--- a/.golangci.goheader.template
+++ b/.golangci.goheader.template
@@ -1,4 +1,4 @@
-Copyright © {{ YEAR }} Meroxa, Inc.
+Copyright © {{ copyright-year }} Meroxa, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,9 @@ linters-settings:
     ignore-tests: true
   goheader:
     template-path: '.golangci.goheader.template'
+    values:
+      regexp:
+        copyright-year: 20[2-9]\d
 
 issues:
   exclude-rules:


### PR DESCRIPTION
### Description

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-s3/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
