### PR TITLE
fix warning log format

### DIFF
--- a/source/iterator/combined_iterator.go
+++ b/source/iterator/combined_iterator.go
@@ -40,6 +40,7 @@ type CombinedIterator struct {
 }
 
 func NewCombinedIterator(
+	ctx context.Context,
 	bucket, prefix string,
 	pollingPeriod time.Duration,
 	client *s3.Client,
@@ -56,7 +57,10 @@ func NewCombinedIterator(
 	switch p.Type {
 	case position.TypeSnapshot:
 		if len(p.Key) != 0 {
-			fmt.Printf("Warning: got position: %s, snapshot will be restarted from the beginning of the bucket\n", p.ToRecordPosition())
+			sdk.Logger(ctx).
+				Warn().
+				Str("position", string(p.ToRecordPosition())).
+				Msg("previous snapshot did not complete successfully. snapshot will be restarted for consistency.")
 		}
 		p = position.Position{} // always start snapshot from the beginning, so position is nil
 		c.snapshotIterator, err = NewSnapshotIterator(bucket, prefix, client, p)

--- a/source/source.go
+++ b/source/source.go
@@ -96,7 +96,7 @@ func (s *Source) Open(ctx context.Context, rp sdk.Position) error {
 	}
 
 	s.iterator, err = iterator.NewCombinedIterator(
-		s.config.AWSBucket, s.config.Prefix, s.config.PollingPeriod, s.client, p,
+		ctx, s.config.AWSBucket, s.config.Prefix, s.config.PollingPeriod, s.client, p,
 	)
 	if err != nil {
 		return fmt.Errorf("couldn't create a combined iterator: %w", err)


### PR DESCRIPTION
### Description

for consistency, this warning was just a printed string, now it uses the SDK logger

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-s3/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
