### PR TITLE
Don't set iterator to nil

### DIFF
--- a/source/source.go
+++ b/source/source.go
@@ -119,7 +119,6 @@ func (s *Source) Read(ctx context.Context) (sdk.Record, error) {
 func (s *Source) Teardown(_ context.Context) error {
 	if s.iterator != nil {
 		s.iterator.Stop()
-		s.iterator = nil
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

This can cause a panic if read is called after the iterator is set to nil.

### To reproduce

1. Create a pipeline with s3 as the source and [chaos](https://github.com/conduitio-labs/conduit-connector-chaos) as the destination.
2. Set up chaos to return an error on `Open`.
3. Start pipeline.

Conduit will start the nodes, the destination connector crashes right away and causes the `Teardown` method to be called in the connector asynchronously. It will cause the iterator to be set to `nil` while the `Read` method is called in another goroutine, that will cause a nil pointer error.