### PR TITLE
Improve S3 key generation logic in the writer

### DIFF
--- a/connector.yaml
+++ b/connector.yaml
@@ -62,7 +62,7 @@ specification:
     time `Write` is called, a new record is added to the buffer. When the buffer is
     full, all the records from it will be written to the S3 bucket, and an ack
     function will be called for each record after being written.
-  version: v0.9.1
+  version: v0.9.2
   author: Meroxa, Inc.
   source:
     parameters:


### PR DESCRIPTION
### Description

Currently the S3 destination connector creates the object's name in the S3 bucket using a timestamp. This change uses the record's key as the object name if available. Otherwise it falls back to the previous method of using the timestamp

Fixes # (issue)

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-s3/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
